### PR TITLE
Remove unecessary cout's from nontrivial_metric_core.h

### DIFF
--- a/CppTransport/templates/nontrivial_metric_core.h
+++ b/CppTransport/templates/nontrivial_metric_core.h
@@ -1805,8 +1805,6 @@ namespace transport
                 $IF{dbrane}
                   // Here, we want to execute the code that works for the dbrane model, with our custom end of inflation searcher
                   if (__x.first[0] <= __params[0]) {
-                    std::cout << __x.first[0] << std::endl;
-                    std::cout << __params[0] << std::endl;
                     return true;
                   }
                   else {


### PR DESCRIPTION
Also committing the removal of the unnecessary cout-ing of various debug information that can now be safely removed into the 201911-dbrane-sampling branch