### PR TITLE
Pull in changes from base ds283-201901 into AlexMaraio-sampling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ matrix:
   include:
 
     - os: linux
-      dist: trusty
-      env: COMPILER_NAME=clang CXX=clang++-3.8 CC=clang-3.8
+      dist: bionic
+      compiler:
+        - gcc
+        - clang
       addons:
         apt:
           sources:
@@ -27,53 +29,10 @@ matrix:
           packages:
             - cmake
             - libsqlite3-dev
-            - libboost1.60-dev
-            - libboost-log1.60-dev
-            - libboost-system1.60-dev
-            - libboost-filesystem1.60-dev
-            - libboost-random1.60-dev
-            - libboost-timer1.60-dev
-            - libboost-date-time1.60-dev
-            - libboost-mpi1.60-dev
-            - libboost-thread1.60-dev
-            - libboost-serialization1.60-dev
-            - libboost-program-options1.60-dev
-            - libboost-regex1.60-dev
+            - libboost-all-dev
             - libginac-dev
             - libopenmpi-dev
             - libssl-dev
-            - gcc-6
-            - g++-6
-            - clang-3.8
-
-    - os: linux
-      dist: trusty
-      env: COMPILER_NAME=gcc CXX=g++-6 CC=gcc-6
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: ppa:samuel-bachmann/boost
-          packages:
-            - cmake
-            - libsqlite3-dev
-            - libboost1.60-dev
-            - libboost-log1.60-dev
-            - libboost-system1.60-dev
-            - libboost-filesystem1.60-dev
-            - libboost-random1.60-dev
-            - libboost-timer1.60-dev
-            - libboost-date-time1.60-dev
-            - libboost-mpi1.60-dev
-            - libboost-thread1.60-dev
-            - libboost-serialization1.60-dev
-            - libboost-program-options1.60-dev
-            - libboost-regex1.60-dev
-            - libginac-dev
-            - libopenmpi-dev
-            - libssl-dev
-            - gcc-6
-            - g++-6
 
 notifications:
 

--- a/CppTransport/translator/backends/infrastructure/language_concepts/cse.h
+++ b/CppTransport/translator/backends/infrastructure/language_concepts/cse.h
@@ -183,6 +183,9 @@ class cse
     //!    this method is used when actually outputting symbols
     std::string get_symbol_with_use_count(const GiNaC::ex& expr);
 
+    //! get number of temporary definitions
+    size_t number_temporaries() const { return this->decls.size(); }
+
     //! clear all current temporary definitions;
     //! typically called when closing one pool and opening another
     void clear();

--- a/CppTransport/translator/backends/infrastructure/language_concepts/lambda_manager.h
+++ b/CppTransport/translator/backends/infrastructure/language_concepts/lambda_manager.h
@@ -188,6 +188,9 @@ class lambda_manager
     std::unique_ptr< std::list<std::string> >
     temporaries(const std::string& left, const std::string& mid, const std::string& right) const;
 
+    //! get number of temporary definitions
+    size_t number_temporaries() const { return this->atomic_cache.size() + this->map_cache.size(); }
+
     //! reset lambda manager on replacement of a temporary pool
     void clear();
 

--- a/CppTransport/translator/backends/shared/fundamental.cpp
+++ b/CppTransport/translator/backends/shared/fundamental.cpp
@@ -27,17 +27,17 @@
 #include <functional>
 #include <time.h>
 
-#include "fundamental.h"
-#include "to_printable.h"
-#include "translation_unit.h"
-#include "formatter.h"
-#include "core.h"
-
 #include "boost/lexical_cast.hpp"
 #include "boost/uuid/uuid.hpp"
 #include "boost/uuid/string_generator.hpp"
 #include "boost/uuid/uuid_io.hpp"
 #include "boost/date_time/posix_time/posix_time.hpp"
+
+#include "fundamental.h"
+#include "to_printable.h"
+#include "translation_unit.h"
+#include "formatter.h"
+#include "core.h"
 
 #include "openssl/md5.h"
 

--- a/CppTransport/translator/backends/shared/temporary_pool.cpp
+++ b/CppTransport/translator/backends/shared/temporary_pool.cpp
@@ -67,6 +67,10 @@ namespace macro_packages
 
     void replace_temp_pool::report_end_of_input()
       {
+        // nothing to do if there are no temporaries to write
+        auto number = this->cse_worker.number_temporaries() + this->lambda_mgr.number_temporaries();
+        if(number == 0) return;
+
         if(!this->tag_set)
           {
             error_context err_ctx = this->data_payload.make_error_context();
@@ -84,95 +88,97 @@ namespace macro_packages
         // deposit any temporaries generated in the current temporary pool,
         // and then reset the CSE agent
 
+        // check if there is any work to do; if not, return
+        auto number = this->cse_worker.number_temporaries() + this->lambda_mgr.number_temporaries();
+        if(number == 0) return;
+
         // however, we should only do something if the location of a temporary pool has been defined
         // (we could get called before that has happened, eg., due to insertion of a kernel)
         // if there is no location defined, we should hold on until one is set later
-        if(tag_set)
+        if(!tag_set) return;
+
+        // get buffer and macro agent associated with current top-of-stack output file;
+        // this will be our own parent macro agent
+        buffer& buf = this->data_payload.get_stack().top_buffer();
+        macro_agent& ma = this->data_payload.get_stack().top_macro_package();
+
+        bool ok = true;
+
+        size_t lhs_pos;
+        size_t rhs_pos;
+
+        if((lhs_pos = this->templ.find("$1")) == std::string::npos)
           {
-            // get buffer and macro agent associated with current top-of-stack output file;
-            // this will be our own parent macro agent
-            buffer& buf = this->data_payload.get_stack().top_buffer();
-            macro_agent& ma = this->data_payload.get_stack().top_macro_package();
+            std::ostringstream msg;
+            msg << ERROR_MISSING_LHS << " '" << this->templ << "'";
 
-            bool ok = true;
+            error_context err_ctx = this->data_payload.make_error_context();
+            err_ctx.error(msg.str());
+            ok = false;
+          }
+        if((rhs_pos = this->templ.find("$2")) == std::string::npos)
+          {
+            std::ostringstream msg;
+            msg << ERROR_MISSING_RHS << " '" << this->templ << "'";
 
-            size_t lhs_pos;
-            size_t rhs_pos;
+            error_context err_ctx = this->data_payload.make_error_context();
+            err_ctx.error(msg.str());
+            ok = false;
+          }
 
-            if((lhs_pos = this->templ.find("$1")) == std::string::npos)
+        if(!ok) return;
+
+        std::string left = this->templ.substr(0, lhs_pos);
+        std::string mid = this->templ.substr(lhs_pos + 2, rhs_pos - lhs_pos - 2);
+        std::string right = this->templ.substr(rhs_pos + 2, std::string::npos);
+
+        // get temporaries which need to be deposited from CSE manager
+        std::unique_ptr<std::list<std::string> > cse_temps = this->cse_worker.temporaries(left, mid, right);
+
+        // get temporaries which need to be deposited from lambda manager
+        std::unique_ptr<std::list<std::string> > lambda_temps = this->lambda_mgr.temporaries(left, mid, right);
+
+        // apply macro replacement to output from temporaries, in case this is required
+        if(cse_temps->size() > 0 || lambda_temps->size() > 0)
+          {
+            std::ostringstream label;
+            label << OUTPUT_TEMPORARY_POOL_START << " (" << OUTPUT_TEMPORARY_POOL_SEQUENCE << "=" <<
+                  this->unique++ << ")";
+            buf.write_to_tag(this->printer.comment(label.str()));
+          }
+
+        for(const std::string& temp : *cse_temps)
+          {
+            unsigned int replacements = 0;
+            std::unique_ptr<std::list<std::string> > r_list = ma.apply(temp, replacements);
+
+            if(r_list)
               {
-                std::ostringstream msg;
-                msg << ERROR_MISSING_LHS << " '" << this->templ << "'";
-    
-                error_context err_ctx = this->data_payload.make_error_context();
-                err_ctx.error(msg.str());
-                ok = false;
-              }
-            if((rhs_pos = this->templ.find("$2")) == std::string::npos)
-              {
-                std::ostringstream msg;
-                msg << ERROR_MISSING_RHS << " '" << this->templ << "'";
-    
-                error_context err_ctx = this->data_payload.make_error_context();
-                err_ctx.error(msg.str());
-                ok = false;
-              }
-
-            std::string left  = this->templ.substr(0, lhs_pos);
-            std::string mid   = this->templ.substr(lhs_pos+2, rhs_pos-lhs_pos-2);
-            std::string right = this->templ.substr(rhs_pos+2, std::string::npos);
-
-            if(ok)
-              {
-                // get temporaries which need to be deposited from CSE manager
-                std::unique_ptr< std::list<std::string> > cse_temps = this->cse_worker.temporaries(left, mid, right);
-
-                // get temporaries which need to be deposited from lambda manager
-                std::unique_ptr< std::list<std::string> > lambda_temps = this->lambda_mgr.temporaries(left, mid, right);
-
-                // apply macro replacement to output from temporaries, in case this is required
-                if(cse_temps->size() > 0 || lambda_temps->size() > 0)
+                for(const std::string& l : *r_list)
                   {
-                    std::ostringstream label;
-                    label << OUTPUT_TEMPORARY_POOL_START << " (" << OUTPUT_TEMPORARY_POOL_SEQUENCE << "=" <<
-                    this->unique++ << ")";
-                    buf.write_to_tag(this->printer.comment(label.str()));
+                    if(l != "") buf.write_to_tag(l);
                   }
-
-                for(const std::string& temp : *cse_temps)
-                  {
-                    unsigned int replacements = 0;
-                    std::unique_ptr< std::list<std::string> > r_list = ma.apply(temp, replacements);
-
-                    if(r_list)
-                      {
-                        for(const std::string& l : *r_list)
-                          {
-                            if(l != "") buf.write_to_tag(l);
-                          }
-                      }
-                  }
-
-                for(const std::string& temp : *lambda_temps)
-                  {
-                    unsigned int replacements = 0;
-                    std::unique_ptr< std::list<std::string> > r_list = ma.apply(temp, replacements);
-
-                    if(r_list)
-                      {
-                        for(const std::string& l : *r_list)
-                          {
-                            if(l != "") buf.write_to_tag(l);
-                          }
-                      }
-                  }
-
-                // clear worker objects; if we don't we might duplicate temporaries we've already written out
-                this->cse_worker.clear();
-                this->lambda_mgr.clear();
               }
           }
-       }
+
+        for(const std::string& temp : *lambda_temps)
+          {
+            unsigned int replacements = 0;
+            std::unique_ptr<std::list<std::string> > r_list = ma.apply(temp, replacements);
+
+            if(r_list)
+              {
+                for(const std::string& l : *r_list)
+                  {
+                    if(l != "") buf.write_to_tag(l);
+                  }
+              }
+          }
+
+        // clear worker objects; if we don't we might duplicate temporaries we've already written out
+        this->cse_worker.clear();
+        this->lambda_mgr.clear();
+      }
 
     std::string replace_temp_pool::evaluate(const macro_argument_list& args)
       {

--- a/CppTransport/translator/msg_en.h
+++ b/CppTransport/translator/msg_en.h
@@ -249,7 +249,8 @@ constexpr auto ERROR_CURRENT_LINE_EMPTY              = "Internal error: current 
 
 constexpr auto ERROR_OUT_OF_BOUNDS_CSE_MAP           = "Internal error: out of bounds subscript in CSE map";
 
-constexpr auto WARNING_TEMPORARY_NO_TAG_SET          = "Temporary pool being written, but no location set (defaults to end-of-buffer, most likely a template bug)";
+constexpr auto WARNING_TEMPORARY_NO_TAG_SET          = "End of input reached, but no location set for temporary buffer. "
+                                                       "This is most likely a template bug, and the translator output is unlikely to compile";
 
 constexpr auto WARNING_HEX_CONVERSION_A              = "Leading '0x' in ";
 constexpr auto WARNING_HEX_CONVERSION_B              = "indicates hex, but did not convert";

--- a/CppTransport/translator/parser/bison/y_parser.yy
+++ b/CppTransport/translator/parser/bison/y_parser.yy
@@ -1,10 +1,10 @@
 %skeleton "lalr1.cc"
-%require "3.0.2"
+%require "3.3"
 %locations
 %defines
 %define api.namespace {y}
 %define api.value.type variant
-%define parser_class_name {y_parser}
+%define api.parser.class {y_parser}
 %define parse.trace
 %define parse.error verbose
 

--- a/CppTransport/transport-runtime/utilities/plot_environment.h
+++ b/CppTransport/transport-runtime/utilities/plot_environment.h
@@ -156,6 +156,8 @@ namespace transport
               {
                 if(env.has_seaborn())
                   {
+                    outf << "from pandas.plotting import register_matplotlib_converters" << '\n';
+                    outf << "register_matplotlib_converters()" << '\n';
                     outf << "import seaborn as sns" << '\n';
                     outf << "sns.set()" << '\n';
                   }


### PR DESCRIPTION
Commit https://github.com/AlexMaraio/CppTransport/commit/16ab628f8f6b921fbe456b910e16571a6e9f6cbd (hopefully) fixed the bug where if there were no temporary pool locations in the template files (e.g. the Cosmosis .ini files or the CMakeLists.txt file) then CppTransport translator would flag this as a warning.