### PR TITLE
Pull in latest 201901 changes from upstream ds283/201901

### DIFF
--- a/CppTransport/templates/canonical_core.h
+++ b/CppTransport/templates/canonical_core.h
@@ -274,13 +274,18 @@ namespace transport
         void C(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __km, double __kn, double __kr, double __N, flattened_tensor<number>& __C) override;
 
         // calculate mass matrix
-        void M(const integration_task<number>* __task, const flattened_tensor<number>& __fields, flattened_tensor<number>& __M) override;
+        void M(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
+               flattened_tensor<number>& __M, massmatrix_type __type = massmatrix_type::include_mixing) override;
 
         // calculate raw mass spectrum
-        void mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool _norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) override;
+        void mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
+                           bool _norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E,
+                           massmatrix_type __type = massmatrix_type::include_mixing) override;
 
         // calculate the sorted mass spectrum, normalized to H^2 if desired
-        void sorted_mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) override;
+        void sorted_mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
+                                  bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E,
+                                  massmatrix_type __type = massmatrix_type::include_mixing) override;
 
         // BACKEND INTERFACE (PARTIAL IMPLEMENTATION -- WE PROVIDE A COMMON BACKGROUND INTEGRATOR)
 
@@ -1384,7 +1389,8 @@ namespace transport
 
 
     template <typename number>
-    void $MODEL<number>::M(const integration_task<number>* __task, const flattened_tensor<number>& __fields, flattened_tensor<number>& __M)
+    void $MODEL<number>::M(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
+                           flattened_tensor<number>& __M, massmatrix_type __type)
       {
         DEFINE_INDEX_TOOLS
         $RESOURCE_RELEASE
@@ -1404,16 +1410,33 @@ namespace transport
 
         $TEMP_POOL{"const auto $1 = $2;"}
 
-        __M[FIELDS_FLATTEN($a,$b)] = $M_TENSOR[ab];
+        switch(__type)
+          {
+            case massmatrix_type::include_mixing:
+              {
+                __M[FIELDS_FLATTEN($a,$b)] = $M_TENSOR[ab];
+                break;
+              }
+
+            case massmatrix_type::hessian_approx:
+              {
+                __M[FIELDS_FLATTEN($a,$b)] = $DDV[ab];
+                break;
+              }
+
+            default:
+              assert(false);
+          }
       }
 
 
     template <typename number>
     void $MODEL<number>::sorted_mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
-                                              bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E)
+                                              bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E,
+                                              massmatrix_type __type)
       {
         // get raw, unsorted mass spectrum in __E
-        this->mass_spectrum(__task, __fields, __norm, __M, __E);
+        this->mass_spectrum(__task, __fields, __norm, __M, __E, __type);
 
         // sort mass spectrum into order
         std::sort(__E.begin(), __E.end());
@@ -1422,12 +1445,13 @@ namespace transport
 
     template <typename number>
     void $MODEL<number>::mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
-                                       bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E)
+                                       bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E,
+                                       massmatrix_type __type)
       {
         DEFINE_INDEX_TOOLS
 
         // write mass matrix (in canonical format) into __M
-        this->M(__task, __fields, __M);
+        this->M(__task, __fields, __M, __type);
 
         // copy elements of the mass matrix into an Eigen matrix
         __mass_matrix($a,$b) = __M[FIELDS_FLATTEN($a,$b)];

--- a/CppTransport/templates/canonical_core.h
+++ b/CppTransport/templates/canonical_core.h
@@ -1439,7 +1439,7 @@ namespace transport
         // so we have to copy between the two
         auto __evalues = __mass_matrix.template selfadjointView<Eigen::Upper>().eigenvalues();
 
-        // if normalized values requested, divide through by 1/H^2
+        // if normalized values requested, divide through by H^2
         if(__norm)
           {
             DEFINE_INDEX_TOOLS

--- a/CppTransport/templates/canonical_core.h
+++ b/CppTransport/templates/canonical_core.h
@@ -277,7 +277,7 @@ namespace transport
         void M(const integration_task<number>* __task, const flattened_tensor<number>& __fields, flattened_tensor<number>& __M) override;
 
         // calculate raw mass spectrum
-        void mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, flattened_tensor<number>& __M, flattened_tensor<number>& __E) override;
+        void mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool _norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) override;
 
         // calculate the sorted mass spectrum, normalized to H^2 if desired
         void sorted_mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) override;
@@ -1413,10 +1413,31 @@ namespace transport
                                               bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E)
       {
         // get raw, unsorted mass spectrum in __E
-        this->mass_spectrum(__task, __fields, __M, __E);
+        this->mass_spectrum(__task, __fields, __norm, __M, __E);
 
         // sort mass spectrum into order
         std::sort(__E.begin(), __E.end());
+      }
+
+
+    template <typename number>
+    void $MODEL<number>::mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
+                                       bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E)
+      {
+        DEFINE_INDEX_TOOLS
+
+        // write mass matrix (in canonical format) into __M
+        this->M(__task, __fields, __M);
+
+        // copy elements of the mass matrix into an Eigen matrix
+        __mass_matrix($a,$b) = __M[FIELDS_FLATTEN($a,$b)];
+
+        // extract eigenvalues from this matrix
+        // In general Eigen would give us complex results, which we'd like to avoid. That can be done by
+        // forcing Eigen to use a self-adjoint matrix, which has guaranteed real eigenvalues.
+        // Also, note that Eigen gives us back the results as an Eigen vector, not a flattened_tensor,
+        // so we have to copy between the two
+        auto __evalues = __mass_matrix.template selfadjointView<Eigen::Upper>().eigenvalues();
 
         // if normalized values requested, divide through by 1/H^2
         if(__norm)
@@ -1436,30 +1457,14 @@ namespace transport
 
             const auto __Hsq = $HUBBLE_SQ;
 
-            __E[$a] = __E[$a] / __Hsq;
-          };
-      }
-
-
-    template <typename number>
-    void $MODEL<number>::mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
-                                        flattened_tensor<number>& __M, flattened_tensor<number>& __E)
-      {
-        DEFINE_INDEX_TOOLS
-
-        // write mass matrix (in canonical format) into __M
-        this->M(__task, __fields, __M);
-
-        // copy elements of the mass matrix into an Eigen matrix
-        __mass_matrix($a,$b) = __M[FIELDS_FLATTEN($a,$b)];
-
-        // extract eigenvalues from this matrix
-        // In general Eigen would give us complex results, which we'd like to avoid. That can be done by
-        // forcing Eigen to use a self-adjoint matrix, which has guaranteed real eigenvalues
-        auto __evalues = __mass_matrix.template selfadjointView<Eigen::Upper>().eigenvalues();
-
-        // copy eigenvalues into output matrix
-        __E[FIELDS_FLATTEN($a)] = __evalues($a);
+            // copy eigenvalues into output matrix
+            __E[$a] = __evalues($a) / __Hsq;
+          }
+        else
+          {
+            // copy eigenvalues into output matrix
+            __E[FIELDS_FLATTEN($a)] = __evalues($a);
+          }
       }
 
 
@@ -1609,7 +1614,7 @@ namespace transport
 
             number largest_evalue(const backg_state<number>& fields)
               {
-                this->mdl->mass_spectrum(this->task, fields, this->flat_M, this->flat_E);
+                this->mdl->mass_spectrum(this->task, fields, false, this->flat_M, this->flat_E);
 
                 // step through eigenvalue vector, extracting largest absolute value
                 number largest_eigenvalue = -std::numeric_limits<number>().max();

--- a/CppTransport/templates/nontrivial_metric_core.h
+++ b/CppTransport/templates/nontrivial_metric_core.h
@@ -1720,7 +1720,7 @@ namespace transport
         // forcing Eigen to use a self-adjoint matrix, which has guaranteed real eigenvalues
         auto __evalues = __mass_matrix.template selfadjointView<Eigen::Upper>().eigenvalues();
 
-        // if normalized values requested, divide through by 1/H^2
+        // if normalized values requested, divide through by H^2
         if(__norm)
           {
             DEFINE_INDEX_TOOLS

--- a/CppTransport/templates/nontrivial_metric_core.h
+++ b/CppTransport/templates/nontrivial_metric_core.h
@@ -291,7 +291,7 @@ namespace transport
         void M(const integration_task<number>* __task, const flattened_tensor<number>& __fields, flattened_tensor<number>& __M) override;
 
         // calculate raw mass spectrum
-        void mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, flattened_tensor<number>& __M, flattened_tensor<number>& __E) override;
+        void mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool _norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) override;
 
         // calculate the sorted mass spectrum, normalized to H^2 if desired
         void sorted_mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) override;
@@ -1696,10 +1696,29 @@ namespace transport
                                               bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E)
       {
         // get raw, unsorted mass spectrum in __E
-        this->mass_spectrum(__task, __fields, __M, __E);
+        this->mass_spectrum(__task, __fields, __norm, __M, __E);
 
         // sort mass spectrum into order
         std::sort(__E.begin(), __E.end());
+      }
+
+
+    template <typename number>
+    void $MODEL<number>::mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
+                                       bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E)
+      {
+        DEFINE_INDEX_TOOLS
+
+        // write mass matrix (in canonical format) into __M
+        this->M(__task, __fields, __M);
+
+        // copy elements of the mass matrix into an Eigen matrix
+        __mass_matrix($^a,$_b) = __M[FIELDS_FLATTEN($^a,$_b)];
+
+        // extract eigenvalues from this matrix
+        // In general Eigen would give us complex results, which we'd like to avoid. That can be done by
+        // forcing Eigen to use a self-adjoint matrix, which has guaranteed real eigenvalues
+        auto __evalues = __mass_matrix.template selfadjointView<Eigen::Upper>().eigenvalues();
 
         // if normalized values requested, divide through by 1/H^2
         if(__norm)
@@ -1719,30 +1738,14 @@ namespace transport
 
             const auto __Hsq = $HUBBLE_SQ;
 
-            __E[$^a] = __E[$^a] / __Hsq;
-          };
-      }
-
-
-    template <typename number>
-    void $MODEL<number>::mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
-                                       flattened_tensor<number>& __M, flattened_tensor<number>& __E)
-      {
-        DEFINE_INDEX_TOOLS
-
-        // write mass matrix (in canonical format) into __M
-        this->M(__task, __fields, __M);
-
-        // copy elements of the mass matrix into an Eigen matrix
-        __mass_matrix($^a,$_b) = __M[FIELDS_FLATTEN($^a,$_b)];
-
-        // extract eigenvalues from this matrix
-        // In general Eigen would give us complex results, which we'd like to avoid. That can be done by
-        // forcing Eigen to use a self-adjoint matrix, which has guaranteed real eigenvalues
-        auto __evalues = __mass_matrix.template selfadjointView<Eigen::Upper>().eigenvalues();
-
-        // copy eigenvalues into output matrix
-        __E[FIELDS_FLATTEN($^a)] = __evalues($^a);
+            // copy eigenvalues into output matrix
+            __E[$^a] = __evalues($^a) / __Hsq;
+          }
+        else
+          {
+            // copy eigenvalues into output matrix
+            __E[FIELDS_FLATTEN($^a)] = __evalues($^a);
+          }
       }
 
 
@@ -1897,7 +1900,7 @@ namespace transport
 
             number largest_evalue(const backg_state<number>& fields)
               {
-                this->mdl->mass_spectrum(this->task, fields, this->flat_M, this->flat_E);
+                this->mdl->mass_spectrum(this->task, fields, false, this->flat_M, this->flat_E);
 
                 // step through eigenvalue vector, extracting largest absolute value
                 number largest_eigenvalue = -std::numeric_limits<number>().max();

--- a/CppTransport/translator/transport-objects/canonical/tensors/M.cpp
+++ b/CppTransport/translator/transport-objects/canonical/tensors/M.cpp
@@ -88,9 +88,9 @@ namespace canonical
     GiNaC::ex M::expr(const GiNaC::ex& Vij, const GiNaC::ex& Vi, const GiNaC::ex& Vj, const GiNaC::ex& deriv_i,
                       const GiNaC::ex& deriv_j)
       {
-        GiNaC::ex u = Vij/Hsq;
-        u += (3-eps) * deriv_i * deriv_j / (Mp*Mp);
-        u += ( deriv_i*Vj + deriv_j*Vi ) / (Mp*Mp*Hsq);
+        GiNaC::ex u = Vij;
+        u += (3-eps) * deriv_i * deriv_j * Hsq / (Mp*Mp);
+        u += ( deriv_i*Vj + deriv_j*Vi ) / (Mp*Mp);
 
         return u;
       }

--- a/CppTransport/transport-runtime/defaults.h
+++ b/CppTransport/transport-runtime/defaults.h
@@ -133,7 +133,7 @@ namespace transport
 
     // maximum number of iterations and search tolerance to use when root-finding to compute horizon exit times
     constexpr boost::uintmax_t CPPTRANSPORT_MAX_ITERATIONS                 = 500;
-    constexpr double           CPPTRANSPORT_ROOT_FIND_TOLERANCE            = 5E-6;
+    constexpr double           CPPTRANSPORT_ROOT_FIND_TOLERANCE            = 1E-4;
     constexpr double           CPPTRANSPORT_ROOT_FIND_ACCURACY             = 1E-3;
 
     // default maximum size which can be automatically VACUUMed

--- a/CppTransport/transport-runtime/models/model.h
+++ b/CppTransport/transport-runtime/models/model.h
@@ -344,7 +344,7 @@ namespace transport
         // MASS SPECTRUM
 
         //! compute the raw mass spectrum
-        virtual void mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, flattened_tensor<number>& __M, flattened_tensor<number>& __E) = 0;
+        virtual void mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) = 0;
 
         //! obtain the sorted mass spectrum, normalized to the Hubble rate^2 if desired
         virtual void sorted_mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) = 0;

--- a/CppTransport/transport-runtime/models/model.h
+++ b/CppTransport/transport-runtime/models/model.h
@@ -139,6 +139,12 @@ namespace transport
     
     template <typename number>
     using backg_history = std::vector< backg_state<number> >;
+
+
+    enum class massmatrix_type
+      {
+        include_mixing, hessian_approx
+      };
     
     
     // ABSTRACT MODEL CLASS
@@ -250,13 +256,14 @@ namespace transport
       public:
 
 		    //! Validate initial conditions
-		    virtual void validate_ics(const parameters<number>& params, const flattened_tensor<number>& input, flattened_tensor<number>& output) = 0;
+        virtual void validate_ics(const parameters<number>& params, const flattened_tensor<number>& input,
+                                  flattened_tensor<number>& output) = 0;
 
         //! Compute initial conditions which give horizon-crossing at time Ncross,
         //! if we allow Npre e-folds before horizon-crossing.
         //! The supplied parameters should have been validated.
-        void offset_ics(const parameters<number>& params, const flattened_tensor<number>& input, flattened_tensor<number>& output,
-                        double Ninit, double Ncross, double Npre,
+        void offset_ics(const parameters<number>& params, const flattened_tensor<number>& input,
+                        flattened_tensor<number>& output, double Ninit, double Ncross, double Npre,
                         double tolerance = CPPTRANSPORT_DEFAULT_ICS_GAP_TOLERANCE,
                         unsigned int time_steps = CPPTRANSPORT_DEFAULT_ICS_TIME_STEPS);
 
@@ -304,50 +311,72 @@ namespace transport
         // GAUGE TRANSFORMATIONS
         
         // these calculate configuration-dependent gauge transformations using full cosmological perturbation theory
-        
+
         //! compute first-order gauge transformation
-        virtual void compute_gauge_xfm_1(const integration_task<number>* __task, const flattened_tensor<number>& __state, flattened_tensor<number>& __dN) = 0;
+        virtual void
+        compute_gauge_xfm_1(const integration_task<number>* __task, const flattened_tensor<number>& __state,
+                            flattened_tensor<number>& __dN) = 0;
 
         //! compute second-order gauge transformation
-        virtual void compute_gauge_xfm_2(const integration_task<number>* __task, const flattened_tensor<number>& __state, double __k, double __k1, double __k2, double __N, flattened_tensor<number>& __ddN) = 0;
+        virtual void
+        compute_gauge_xfm_2(const integration_task<number>* __task, const flattened_tensor<number>& __state, double __k,
+                            double __k1, double __k2, double __N, flattened_tensor<number>& __ddN) = 0;
 
-        
+
         // TENSORS
 
         // calculate tensor quantities, including the 'flow' tensors u2, u3 and the basic tensors A, B, C from which u3 is built
 
         //! compute u2 tensor in 'standard' index configuration (first index up, remaining indices down)
-        virtual void u2(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __k, double __N, flattened_tensor<number>& __u2) = 0;
+        virtual void
+        u2(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __k, double __N,
+           flattened_tensor<number>& __u2) = 0;
 
         //! compute u3 tensor in 'standard' index configuration (first index up, remaining indices down)
-        virtual void u3(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __km, double __kn, double __kr, double __N, flattened_tensor<number>& __u3) = 0;
-    
+        virtual void
+        u3(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __km, double __kn,
+           double __kr, double __N, flattened_tensor<number>& __u3) = 0;
+
         //! compute A tensor in 'standard' index configuration (all indices down)
         //! currently A isn't used by the platform, so the precise index arrangement is arbitrary
-        virtual void A(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __km, double __kn, double __kr, double __N, flattened_tensor<number>& __A) = 0;
-    
+        virtual void
+        A(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __km, double __kn,
+          double __kr, double __N, flattened_tensor<number>& __A) = 0;
+
         //! compute B tensor in 'standard' index configuration (last index up, first two indices down)
         //! this is the index configuration needed for shifting a correlation function from momenta
         //! to time derivatives
-        virtual void B(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __km, double __kn, double __kr, double __N, flattened_tensor<number>& __B) = 0;
-    
+        virtual void
+        B(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __km, double __kn,
+          double __kr, double __N, flattened_tensor<number>& __B) = 0;
+
         //! compute C tensor in 'standard' index configuration (first index up, last two indices down)
         //! this is the index configuration needed for shifting a correlation function from momenta
         //! to time derivatives
-        virtual void C(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __km, double __kn, double __kr, double __N, flattened_tensor<number>& __C) = 0;
-    
+        virtual void
+        C(const integration_task<number>* __task, const flattened_tensor<number>& __fields, double __km, double __kn,
+          double __kr, double __N, flattened_tensor<number>& __C) = 0;
+
         //! compute M tensor in 'standard' index configuration (first index up, second index down)
         //! this is the arrangement needed to compute the mass spectrum
-        virtual void M(const integration_task<number>* __task, const flattened_tensor<number>& __fields, flattened_tensor<number>& __M) = 0;
+        virtual void
+        M(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
+          flattened_tensor<number>& __M, massmatrix_type __type = massmatrix_type::include_mixing) = 0;
 
 
         // MASS SPECTRUM
 
         //! compute the raw mass spectrum
-        virtual void mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) = 0;
+        virtual void
+        mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool __norm,
+                      flattened_tensor<number>& __M, flattened_tensor<number>& __E,
+                      massmatrix_type __type = massmatrix_type::include_mixing) = 0;
 
         //! obtain the sorted mass spectrum, normalized to the Hubble rate^2 if desired
-        virtual void sorted_mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields, bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E) = 0;
+        virtual void
+        sorted_mass_spectrum(const integration_task<number>* __task, const flattened_tensor<number>& __fields,
+                             bool __norm, flattened_tensor<number>& __M, flattened_tensor<number>& __E,
+                             massmatrix_type __type = massmatrix_type::include_mixing) = 0;
 
 
         // BACKEND
@@ -371,7 +400,9 @@ namespace transport
         // process a background computation
         // unlike the twopf and threepf cases, we assume this can be done in memory
         // suitable storage is passed in soln
-        virtual void backend_process_backg(const background_task<number>* tk, std::vector< flattened_tensor<number> >& solution, bool silent=false) = 0;
+        virtual void
+        backend_process_backg(const background_task<number>* tk, std::vector<flattened_tensor<number> >& solution,
+                              bool silent = false) = 0;
 
         // process a work list of twopf items
         // must be over-ridden by a derived implementation class

--- a/CppTransport/transport-runtime/tasks/integration_detail/threepf_task.h
+++ b/CppTransport/transport-runtime/tasks/integration_detail/threepf_task.h
@@ -353,10 +353,10 @@ namespace transport
             // forward to underlying twopf_db_task to update its database;
             // should be done *before* computing horizon exit times for threepfs, so that horizon exit & massless times
             // for the corresponding twopfs are known
-            this->twopf_db_task<number>::twopf_compute_horizon_exit_times(log_aH_sp, log_a2H2M_sp, task_impl::TolerancePredicate<number>{this->name, CPPTRANSPORT_ROOT_FIND_TOLERANCE});
+            this->twopf_db_task<number>::twopf_compute_horizon_exit_times(log_aH_sp, log_a2H2M_sp, task_impl::HorizonExitTolerancePredicate<number>{this->name, CPPTRANSPORT_ROOT_FIND_TOLERANCE});
 
             // compute horizon exit times & massless times for threepf configuraitons
-            this->threepf_compute_horizon_exit_times(log_aH_sp, task_impl::TolerancePredicate<number>{this->name, CPPTRANSPORT_ROOT_FIND_TOLERANCE});
+            this->threepf_compute_horizon_exit_times(log_aH_sp, task_impl::HorizonExitTolerancePredicate<number>{this->name, CPPTRANSPORT_ROOT_FIND_TOLERANCE});
           }
         catch(failed_to_compute_horizon_exit& xe)
           {


### PR DESCRIPTION
There have been some changes made to the upstream repository `ds283/201901` from which this branch is forked from. Pulling in these changes so that way when we merge sampling it should be as easy as possible.

- This looks to be mostly related to the mass-matrix improvements and using a better tolerance condition on the horizon exit splines.